### PR TITLE
Make placeholder parameter valid from 2012 to pass tests

### DIFF
--- a/openfisca_loiret/parameters/loiret/apa/forfait.yaml
+++ b/openfisca_loiret/parameters/loiret/apa/forfait.yaml
@@ -1,5 +1,5 @@
 description: Montant forfaitaire fictif de l'APA pour le département du Loiret
 unit: currency
 values:
-  2017-01-01:
+  2012-01-01:
     value: 100


### PR DESCRIPTION
Certains tests sur mes-aides.gouv.fr/tests datent de 2014 et le paramètre du Loiret n'était défini qu'à partir de 2017 ce qui générait des erreurs.